### PR TITLE
Updated displayed version from 11 to 12

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,7 +33,7 @@ theme = "hugo-elate-theme"
 
   # Hero section
   [params.hero]
-    title = 'JavaFX 11'
+    title = 'JavaFX 12'
     subtitle = 'OpenJFX is an open source, next generation client application platform for desktop, mobile and embedded systems built on Java.</br> It is a collaborative effort by many individuals and companies with the goal of producing a modern, efficient, and fully featured toolkit for developing rich client applications.</br></br>'
 
   # Intro section
@@ -42,7 +42,7 @@ theme = "hugo-elate-theme"
 
   [[params.intro.item]]
     title = "Download"
-    description = 'The JavaFX 11 runtime is available as a platform-specifc SDK, as a number of jmods, and as a set of artifacts in Maven Central.'
+    description = 'The JavaFX 12 runtime is available as a platform-specifc SDK, as a number of jmods, and as a set of artifacts in Maven Central.'
     url = "https://gluonhq.com/products/javafx/"
     button = "Download"
     icon = "icon-cloud-download"
@@ -70,15 +70,15 @@ theme = "hugo-elate-theme"
 
     [[params.documentation.item]]
       title = "Release Notes"
-      description = "Read about what is new in JavaFX 11"
-      url = "https://github.com/javafxports/openjdk-jfx/blob/jfx-11/doc-files/release-notes-11.md#release-notes-for-javafx-11"
+      description = "Read about what is new in JavaFX 12"
+      url = "https://github.com/javafxports/openjdk-jfx/blob/jfx-12/doc-files/release-notes-12.md#release-notes-for-javafx-12"
       button = "Visit"
       icon = "icon-book-open"
       img = "img_7.jpg"
 
     [[params.documentation.item]]
       title = "Getting Started"
-      description = "Get started quickly and easily with JavaFX 11"
+      description = "Get started quickly and easily with JavaFX 12"
       url = "/openjfx-docs/"
       button = "Visit"
       icon = "icon-book-open"
@@ -86,8 +86,8 @@ theme = "hugo-elate-theme"
 
     [[params.documentation.item]]
       title = "Javadoc"
-      description = "API documentation for JavaFX 11"
-      url = "/javadoc/11/"
+      description = "API documentation for JavaFX 12"
+      url = "/javadoc/12/"
       button = "Visit"
       icon = "icon-book-open"
       img = "img_10.jpg"
@@ -188,7 +188,7 @@ theme = "hugo-elate-theme"
   [params.work]
     enable = true
     title = "Community"
-    description = "JavaFX features a vibrant and passionate developer community. This enthusiasm can be found in the <a href='http://mail.openjdk.java.net/mailman/listinfo/openjfx-dev' target='_blank'>open source mailing list</a>. Here are a few examples of tools and frameworks already supporting JavaFX 11."
+    description = "JavaFX features a vibrant and passionate developer community. This enthusiasm can be found in the <a href='http://mail.openjdk.java.net/mailman/listinfo/openjfx-dev' target='_blank'>open source mailing list</a>. Here are a few examples of tools and frameworks already supporting JavaFX 12."
     footertext = ''
 
     [[params.work.row]]
@@ -279,7 +279,7 @@ theme = "hugo-elate-theme"
   [params.services]
     enable = false
     title = "Community"
-    description = "JavaFX features a vibrant and passionate developer community. This enthusiasm can be found in the open source mailing list, the forum discussions. Here just some of the examples of tools and frameworks already supporting JavaFX 11"
+    description = "JavaFX features a vibrant and passionate developer community. This enthusiasm can be found in the open source mailing list, the forum discussions. Here just some of the examples of tools and frameworks already supporting JavaFX 12"
 
     [[params.services.item]]
       title = '<a href="https://dlsc.com/products/flexganttfx/" target="_blank">FlexGanttFX</a>'


### PR DESCRIPTION
Addresses #9.

Notes:

* Changed "Here are a few examples of tools and frameworks already supporting JavaFX 11" to 12 even though I didn't test that they work with 12, I assume that they still do since nothing major changed. Not sure if this is fine.
* Didn't change the testimonials obviously, they still talk about 11.
* Changed "Getting Started" to say 12, but the link still takes to the 11 instructions because it's controlled by another repo (https://github.com/openjfx/openjfx-docs). I changed under the assumption that one will be updated as well.

Feel free to update/revert version locations.